### PR TITLE
Update manifest docs to offer better clarity for the host key

### DIFF
--- a/src/pages/develop/plugin-development/plugin-structure/manifest.md
+++ b/src/pages/develop/plugin-development/plugin-structure/manifest.md
@@ -60,16 +60,16 @@ The top level of the manifest JSON object contains high-level information about 
 | `name`            | `string`                                              | The name should be 3 - 45 characters. <br/> **Note:** We recommend your plugin name matches the _project name_ you created when getting your plugin ID from the Adobe Developer Console.                                                                                                                                                                                                                           | Develop / Publish |
 | `version`         | `string`                                              | Version number of your plugin in `x.y.z` format. <br/>Version must be three segments and each version component must be between `0` and `99`.                                                                                                                                                                                                                                                                      | Develop / Publish |
 | `main`   | `string` | Path to the your plugin initialization code. This can be a JavaScript file or an HTML file. | Optional (defaults to `main.js`) |
-| `icons`           | `array<object>`                                       | Icons displayed in XD's plugins panel. <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> Two sizes are required - 24px and 48px. <br/> **Note:** Icons for XD's Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](/distribution/packaging-your-plugin/) to learn more. | Publish           |
-| `host.app`        | `string`                                              | Indicates that this is a plugin for Adobe XD (currently, the only valid value here is `"XD"`).                                                                                                                                                                                                                                                                                                                     | Develop / Publish |
-| `host.minVersion` | `string`                                              | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `36.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `16.0`.                                                                          | Develop / Publish |
-| `host.maxVersion` | `string`                                              | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`.                                                                                                                                                                                                                                                                                                                        | Optional          |
-| `entryPoints` | `EntryPointDefinition]`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish |
+| `icons`           | `array<IconDefinition>`                                       | Icons displayed in XD's plugins panel. <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> Two sizes are required - 24px and 48px. <br/> **Note:** Icons for XD's Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](/distribution/packaging-your-plugin/) to learn more. | Publish           |
+| `host`            | `array<HostDefinition>`                                       | Describes the supported applications that can be used with this plugin. This can include the type of application, the minimum required version, or the maximum version of the host app that the plugin supports.  | Develop / Publish |
+| `entryPoints` | `array<EntryPointDefinition>`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish |
 
 ## Icons
 
 Icons are not required during development, but *must be provided* when distributing through the Plugin Marketplace.
 The `icons` field is an array of a `IconDefinition`s:
+
+### IconDefinition
 
 Key | Type | Description
 ----|------|----------------
@@ -80,9 +80,21 @@ Key | Type | Description
 `theme` | `string[]` | Array of themes this icon supports. XD doesn't yet support themes, so you can remove this key, or you can use `all`. (Default is `all`).
 `species` | `string[]` | Identifies the type of icon and where it would make sense to display it. The default is `generic`, meaning that XD is free to use this icon anywhere. For XD panels, you should generally use `pluginList` -- this tells XD that the icon is suitable for display in the Plugins Panel.
 
+## Hosts
+
+The `host` field is an _array_ of objects matching the `HostDefinition` format specified below. These entries allow your plugin to be ran on multiple apps such as Adobe XD or Photoshop. Optionally, the field can contain a HostDefinition instead of a full array if only one type of app is being supported.
+
+### HostDefinition
+
+Key | Type | Description | Required
+----|------|-------------| --------
+`app` | `string` | Indicates that this is a plugin for Adobe XD (currently, the only valid values here are `"XD"` and `"PS"`). | Develop / Publish |
+`minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `36.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `16.0`. | Develop / Publish |
+`maxVersion` | `string` | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`. | Optional |
+
 ## Entry Points
 
-The `entryPoints` field is an _array_ of objects matching the EntryPointDefinition format specified below. These entries appear both in the _Plugins_ menu in the native menubar, and the "plugin launchpad" sidebar panel. See [Plugin menu structure](/develop/plugin-development/plugin-structure/menu-structure/) for details on how these entries are displayed.
+The `entryPoints` field is an _array_ of objects matching the `EntryPointDefinition` format specified below. These entries appear both in the _Plugins_ menu in the native menubar, and the "plugin launchpad" sidebar panel. See [Plugin menu structure](/develop/plugin-development/plugin-structure/menu-structure/) for details on how these entries are displayed.
 
 Each entry point specifies a `type`, to create either a direct-action command or a panel show/hide command.
 

--- a/src/pages/develop/plugin-development/plugin-structure/manifest.md
+++ b/src/pages/develop/plugin-development/plugin-structure/manifest.md
@@ -88,8 +88,8 @@ The `host` field is an _array_ of objects matching the `HostDefinition` format s
 
 Key | Type | Description | Required
 ----|------|-------------| --------
-`app` | `string` | Indicates that this is a plugin for Adobe XD (currently, the only valid values here are `"XD"` and `"PS"`). | Develop / Publish
-`minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `36.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `16.0`. | Develop / Publish
+`app` | `string` | Indicates the supported application for this plugin (currently, the only valid values here are `"XD"` and `"PS"`). | Develop / Publish
+`minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `36.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `36.0`. | Develop / Publish
 `maxVersion` | `string` | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`. | Optional
 
 ## Entry Points

--- a/src/pages/develop/plugin-development/plugin-structure/manifest.md
+++ b/src/pages/develop/plugin-development/plugin-structure/manifest.md
@@ -67,7 +67,7 @@ The top level of the manifest JSON object contains high-level information about 
 ## Icons
 
 Icons are not required during development, but *must be provided* when distributing through the Plugin Marketplace.
-The `icons` field is an array of a `IconDefinition`s:
+The `icons` field is an array of a `IconDefinition`s.
 
 ### IconDefinition
 
@@ -88,9 +88,9 @@ The `host` field is an _array_ of objects matching the `HostDefinition` format s
 
 Key | Type | Description | Required
 ----|------|-------------| --------
-`app` | `string` | Indicates that this is a plugin for Adobe XD (currently, the only valid values here are `"XD"` and `"PS"`). | Develop / Publish |
-`minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `36.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `16.0`. | Develop / Publish |
-`maxVersion` | `string` | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`. | Optional |
+`app` | `string` | Indicates that this is a plugin for Adobe XD (currently, the only valid values here are `"XD"` and `"PS"`). | Develop / Publish
+`minVersion` | `string` | Minimum required version of the host app (in `x.y` format) that can run this plugin. The lowest valid version for manifest V4 plugins is version `36.0`. <br/> **Note:** The version number must be at least two segments. Typically, you'll leave the minor segment set to `0`, e.g. `16.0`. | Develop / Publish
+`maxVersion` | `string` | Maximum version of host app that can run this plugin. Same formatting as `host.minVersion`. | Optional
 
 ## Entry Points
 

--- a/src/pages/develop/plugin-development/plugin-structure/manifest.md
+++ b/src/pages/develop/plugin-development/plugin-structure/manifest.md
@@ -60,9 +60,9 @@ The top level of the manifest JSON object contains high-level information about 
 | `name`            | `string`                                              | The name should be 3 - 45 characters. <br/> **Note:** We recommend your plugin name matches the _project name_ you created when getting your plugin ID from the Adobe Developer Console.                                                                                                                                                                                                                           | Develop / Publish |
 | `version`         | `string`                                              | Version number of your plugin in `x.y.z` format. <br/>Version must be three segments and each version component must be between `0` and `99`.                                                                                                                                                                                                                                                                      | Develop / Publish |
 | `main`   | `string` | Path to the your plugin initialization code. This can be a JavaScript file or an HTML file. | Optional (defaults to `main.js`) |
-| `icons`           | `array<IconDefinition>`                                       | Icons displayed in XD's plugins panel. <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> Two sizes are required - 24px and 48px. <br/> **Note:** Icons for XD's Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](/distribution/packaging-your-plugin/) to learn more. | Publish           |
-| `host`            | `array<HostDefinition>`                                       | Describes the supported applications that can be used with this plugin. This can include the type of application, the minimum required version, or the maximum version of the host app that the plugin supports.  | Develop / Publish |
-| `entryPoints` | `array<EntryPointDefinition>`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish |
+| `icons`           | `IconDefinition[]`                                       | Icons displayed in XD's plugins panel. <br/> PNG, JPG/JPEG formats are supported and the max file size for each icon is 1MB. <br/> Two sizes are required - 24px and 48px. <br/> **Note:** Icons for XD's Plugin Manager are uploaded directly via the Adobe Developer Console, not included within your plugin itself. See our ["Publishing your plugin" guide](/distribution/packaging-your-plugin/) to learn more. | Publish           |
+| `host`            | `HostDefinition\|HostDefinition[]`                                       | Describes the supported applications that can be used with this plugin. This can include the type of application, the minimum required version, or the maximum version of the host app that the plugin supports. <br/><br/> **Note:** An array can ONLY be used during development. A single definition will be needed when submitting to the marketplace  | Develop / Publish |
+| `entryPoints` | `EntryPointDefinition[]`| Describes the entries your plugin adds to the _Plugins_ menu & plugin panel. See the next section for details. | Develop / Publish |
 
 ## Icons
 
@@ -82,7 +82,7 @@ Key | Type | Description
 
 ## Hosts
 
-The `host` field is an _array_ of objects matching the `HostDefinition` format specified below. These entries allow your plugin to be ran on multiple apps such as Adobe XD or Photoshop. Optionally, the field can contain a HostDefinition instead of a full array if only one type of app is being supported.
+The `host` field is an _object_ matching the `HostDefinition` format specified below. This entry allows your plugin to specify which app your plugin can run on such as Adobe XD or Photoshop. During development, the field can contain an _array_ of HostDefinition's. This can be very convient during development of cross-compatible UXP plugins. However, during submission to the marketplace, only one HostDefinition is allowed.
 
 ### HostDefinition
 


### PR DESCRIPTION
## Description

The changes to the manifest documentation aim to make the `host` key clearer in terms of the types of values that it accepts. Currently, there is no written documentation that the key can accept an array of objects. This allows for the ability to create a plugin that is compatible across multiple apps. This is solved with the introduction of the `HostDefinition` object which describes the details on the various applications a plugin can support.

In addition, a few more changes were made to increase the overall consistency of the documentation. These changes include specifying the type of array the `icons` key accepts as well as adding a header and tweaking the styling of the `Entry Points` section

