### PR TITLE
Updated menu-structure to use v4 manifest

### DIFF
--- a/src/pages/develop/plugin-development/plugin-structure/menu-structure.md
+++ b/src/pages/develop/plugin-development/plugin-structure/menu-structure.md
@@ -1,35 +1,35 @@
 # Plugin menu structure
 
-In your [manifest.json](/develop/plugin-development/plugin-structure/manifest/), The `uiEntryPoints` field is an array of objects including all UI entry points your plugin has available. All entries listed in this array appear both in the Plugins menu in the native menubar and the "plugin launchpad" sidebar panel. Let's learn how these items appear in XD.
+In your [manifest.json](/develop/plugin-development/plugin-structure/manifest/), the `entryPoints` field is an array of objects including all UI entry points your plugin has available. All entries listed in this array appear both in the Plugins menu in the native menubar and the "plugin launchpad" sidebar panel. Let's learn how these items appear in XD.
 
 ## Top level name
 
-No matter how many itmes you have in the `uiEntryPoints` array, XD will always use your plugin's name as the top level label for your plugin in the UI. For example, if you have "PLUGIN NAME" as your plugin name in your manifest.json file:
+No matter how many items you have in the `entryPoints` array, XD will always use your plugin's name as the top level label for your plugin in the UI. For example, if you have "PLUGIN NAME" as your plugin name in your manifest.json file:
 
 ```js
 "name": "PLUGIN NAME"
 ```
 
-XD will display this as the top menu item in the native menubar and in the "plugin launchpad":
+XD will display this as the top menu item in the native menubar and in the "plugin launchpad".
 
 <!-- ![menu plugin name](/images/menu-plugin-name.png) -->
 <!-- ![panel plugin name](/images/panel-plugin-name.png) -->
 
 ## Submenu names
 
-So where do the `label`s you specify in `uiEntryPoints` show up in XD? For example, if you have a plugin with one modal-dialog command and one panel:
+So where do the `label`s you specify in `entryPoints` show up in XD? For example, if you have a plugin with one modal-dialog command and one panel:
 
 ```js
-"uiEntryPoints": [
+"entryPoints": [
     {
-        "type": "menu",
-        "label": "This is a modal",
-        "commandId": "test"
+        "type": "command",
+        "id": "test",
+        "label": { "default": "This is a modal" }
     },
     {
         "type": "panel",
-        "label": "this is a panel",
-        "panelId": "enlargeRectangle"
+        "id": "enlargeRectangle",
+        "label": { "default": "this is a panel" }
     }
 ]
 ```
@@ -41,19 +41,19 @@ You will see those labels shown as _submenu_ items under the plugin's name:
 
 ## Single-item plugins
 
-If your plugin has only **one** item in the `uiEntryPoints` array, its `label` will be ignored. Instead of having a single submenu item nested under the plugin's name, XD will simply show the plugin's name itself as a directly actionable top-level menu item, which triggers the plugin's one entry point. For example:
+If your plugin has only **one** item in the `entryPoints` array, its `label` will be ignored. Instead of having a single submenu item nested under the plugin's name, XD will simply show the plugin's name itself as a directly actionable top-level menu item, which triggers the plugin's one entry point. For example:
 
 ```js
-"uiEntryPoints": [
+"entryPoints": [
     {
         "type": "panel",
-        "label": "this is a panel (IGNORED)",
-        "panelId": "enlargeRectangle"
+        "id": "enlargeRectangle",
+        "label": { "default": "this is a panel (IGNORED)" }
     }
 ]
 ```
 
-Since there is only one item in the `uiEntryPoints` array, XD will ignore the `label` and display the plugin's name as the top menu item.
+Since there is only one item in the `entryPoints` array, XD will ignore the `label` and display the plugin's name as the top menu item.
 
 <!-- ![menu plugin one label](/images/menu-plugin-one-label.png) -->
 <!-- ![panel plugin one label](/images/panel-plugin-one-label.png) -->


### PR DESCRIPTION
## Description
Currently, the [Menu Structure](https://www.adobe.io/xd/uxp/develop/plugin-development/plugin-structure/menu-structure/) page of the documentation refers to the old `uiEntryPoints` field instead of the new `entryPoints` field as per manifest version 4. This quick PR aims to update this along with the examples used to conform to the new manifest version